### PR TITLE
bug: Fix line-ending issues in Windows

### DIFF
--- a/internal/tangent/runners/stdiorunner/errors.go
+++ b/internal/tangent/runners/stdiorunner/errors.go
@@ -52,4 +52,8 @@ var (
 	// ErrInvalidArgs is returned for invalid arguments.
 	// Occurs when the arguments are nil.
 	ErrInvalidArgs = ErrShellCommandRunnerError.New("invalid args")
+
+	// ErrDos2UnixNotAvailable is returned when dos2unix command is not available.
+	// Occurs when dos2unix is not installed or not in PATH.
+	ErrDos2UnixNotAvailable = ErrShellCommandRunnerError.New("dos2unix not available")
 )

--- a/internal/tangent/session/hashlog/renderhtml.go
+++ b/internal/tangent/session/hashlog/renderhtml.go
@@ -444,21 +444,13 @@ func renderJSONField(out io.Writer, p map[string]any, fieldKey, fieldLabel, cssC
 
 const cssStyle = `
 :root {
-  --entry-bg: #fefefe;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --entry-bg: #1b1b1b;
-  }
+  --entry-bg: #2a2a2a;
 }
 body {
   font-family: sans-serif;
   margin: 2em;
-  background: #fff;
-  color: #000;
-}
-@media (prefers-color-scheme: dark) {
-  body { background: #111; color: #ccc; }
+  background: #2a2a2a;
+  color: #ddd;
 }
 h1 { font-size: 1.6em; margin-bottom: 0.3em; }
 h2 { font-weight: normal; color: #aaa; font-size: 1em; margin-bottom: 0em; }
@@ -488,13 +480,10 @@ h2 { font-weight: normal; color: #aaa; font-size: 1em; margin-bottom: 0em; }
 }
 pre {
   background: #222;
-  color: #ddd;
+  color: #eee;
   padding: 0.5em;
   border-radius: 4px;
   overflow-x: auto;
-}
-@media (prefers-color-scheme: light) {
-  pre { background: #f6f8fa; color: #333; }
 }
 details summary {
   font-size: 1em;

--- a/internal/tangent/session/hashlog/renderhtml.go
+++ b/internal/tangent/session/hashlog/renderhtml.go
@@ -285,7 +285,6 @@ func RenderHashedLogToHTML(path string, verificationStatus ...VerificationStatus
 	if err != nil {
 		return fmt.Errorf("failed to create html output: %w", err)
 	}
-	defer out.Close()
 
 	// Write HTML content
 	writeHTMLHeader(out, logData, verificationStatus)
@@ -297,7 +296,13 @@ func RenderHashedLogToHTML(path string, verificationStatus ...VerificationStatus
 	fmt.Fprint(out, `</body></html>`)
 
 	if err := out.Sync(); err != nil {
+		out.Close()
 		return fmt.Errorf("failed to sync file to disk: %w", err)
+	}
+
+	// Close the file handle before returning to avoid Windows file locking issues
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close html file: %w", err)
 	}
 
 	return nil

--- a/scripts/docker/Dockerfile.tangent
+++ b/scripts/docker/Dockerfile.tangent
@@ -18,7 +18,7 @@ FROM python:3.12.9-slim-bookworm
 
 # Install only essential system packages (no build tools)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash curl git ca-certificates jq \
+    bash curl git ca-certificates jq dos2unix \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \

--- a/scripts/docker/Dockerfile.tangent.minimal
+++ b/scripts/docker/Dockerfile.tangent.minimal
@@ -23,7 +23,7 @@ FROM alpine:3.19
 RUN apk add --no-cache \
     python3 py3-pip \
     nodejs npm \
-    bash curl git jq ca-certificates \
+    bash curl git jq ca-certificates dos2unix \
     && ln -sf python3 /usr/bin/python
 
 # Install only essential Python packages (using --break-system-packages for Alpine)


### PR DESCRIPTION
- Fix CRLF issues by running dos2unix on scripts.
- Windows specific issue with locking of .tmp files while downloading audit logs.